### PR TITLE
Ignore nodes, new options

### DIFF
--- a/internal/mdrenderer/node_renderer.go
+++ b/internal/mdrenderer/node_renderer.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"sync"
 
+	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	east "github.com/yuin/goldmark/extension/ast"
 	"github.com/yuin/goldmark/renderer"
@@ -79,6 +80,18 @@ type Renderer struct {
 	wasAtNL           bool
 
 	w io.Writer
+}
+
+var _ goldmark.Extender = &Renderer{}
+
+// Extend implements goldmark.Extender.
+func (r *Renderer) Extend(md goldmark.Markdown) {
+	r.AddOptions(
+		renderer.WithOption(options.OptParser, options.ParserOpt{
+			Parser: md.Parser(),
+		}),
+	)
+	md.SetRenderer(r)
 }
 
 var _ renderer.Renderer = &Renderer{}

--- a/internal/options/ignore.go
+++ b/internal/options/ignore.go
@@ -1,0 +1,19 @@
+package options
+
+import (
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/renderer"
+)
+
+const OptIgnore renderer.OptionName = "IgnoreNodeKinds"
+
+type IgnoreOpt struct {
+	Kinds []ast.NodeKind
+}
+
+// Apply implements Option.
+func (t IgnoreOpt) Apply(c *Config) {
+	c.IgnoredNodes = append(c.IgnoredNodes, t.Kinds...)
+}
+
+var _ Option = IgnoreOpt{}

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -28,6 +28,7 @@ type Config struct {
 	LinkTitleQuote      []byte
 	CheckedCheckbox     []byte
 	UncheckedCheckbox   []byte
+	IgnoredNodes        []ast.NodeKind
 }
 
 func DefaultConfig() Config {

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -30,7 +30,7 @@ func roundtrip(t testing.TB, source, expectedHTMLOverride []byte) {
 
 	mdToMd := goldmark.New(
 		goldmark.WithParser(mdToHtml.Parser()),
-		goldmark.WithRenderer(NewRenderer()),
+		goldmark.WithExtensions(NewRenderer()),
 	)
 
 	expectedHtmlBuf := &bytes.Buffer{}

--- a/noderenderer/node_renderer.go
+++ b/noderenderer/node_renderer.go
@@ -6,6 +6,10 @@ import "github.com/yuin/goldmark/ast"
 
 type RenderFunc func(n ast.Node, entering bool) error
 
+func NoopRenderer(n ast.Node, entering bool) error {
+	return nil
+}
+
 type NodeRenderer struct {
 	Kind ast.NodeKind
 	Fn   RenderFunc

--- a/options.go
+++ b/options.go
@@ -1,10 +1,8 @@
 package markdown
 
 import (
-	"github.com/yuin/goldmark/parser"
-	"github.com/yuin/goldmark/renderer"
-
 	"github.com/blackstork-io/goldmark-markdown/internal/options"
+	"github.com/yuin/goldmark/ast"
 )
 
 var (
@@ -13,18 +11,15 @@ var (
 )
 
 // WithThematicBreaks sets the thematic break tags to use, in the order of preference
-func WithThematicBreaks(breaks ...string) renderer.Option {
-	return renderer.WithOption(
-		options.OptThematicBreaks,
-		options.ThematicBreaksOpt(breaks),
-	)
+func WithThematicBreaks(breaks ...string) options.Option {
+	return options.ThematicBreaksOpt(breaks)
 }
 
-// WithParser sets the markdown parser used to verify other options's validity/applicability
-func WithParser(p parser.Parser) renderer.Option {
-	return renderer.WithOption(options.OptParser, options.ParserOpt{
-		Parser: p,
-	})
+// WithIgnoredNodes sets up the renderer to ignore a node, proceeding to render its children
+func WithIgnoredNodes(kind ...ast.NodeKind) options.Option {
+	return options.IgnoreOpt{
+		Kinds: kind,
+	}
 }
 
 // TODO: Create more options

--- a/renderer.go
+++ b/renderer.go
@@ -2,9 +2,10 @@ package markdown
 
 import (
 	"github.com/blackstork-io/goldmark-markdown/internal/mdrenderer"
+	"github.com/blackstork-io/goldmark-markdown/internal/options"
 )
 
-// NewRenderer returns a new renderer. Use [goldmark.WithRenderer] to add it to a goldmark instance.
-func NewRenderer() *mdrenderer.Renderer {
-	return mdrenderer.NewRenderer()
+// NewRenderer returns a new renderer. Use [goldmark.WithExtensions] to add it to a goldmark instance.
+func NewRenderer(opts ...options.Option) *mdrenderer.Renderer {
+	return mdrenderer.NewRenderer(opts...)
 }


### PR DESCRIPTION
* Can use `goldmark.WithExtensions` to both set the parser used internally by goldmark-markdown and the renderer to goldmark-markdown
* Now options are supplied directly at renderer creation
* New option to ignore nodes